### PR TITLE
feat: al bootstrap を実装し、sync の最後で実行する

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ eval "$(al activate bash)"  # bash
 | Profile | 用途別の環境分離（例: work / private） | `al profile add`, `al profile list`, `al profile show` |
 | link.d | dotfiles を `~/.al/link.d/` に集約し、ユーザパスを symlink に | `al link add/list/remove/edit` |
 | shell.d | パッケージごとのシェルスニペットと読み込み順の管理 | `al package shell show/set/edit/enable/disable` |
+| bootstrap | 新規 PC セットアップ用のワンオフシェルスクリプト（`~/.al/bootstrap/script.sh`） | `al bootstrap add/edit/remove/show` |
 | sync / backup | GitHub との clone 適用・push | `al sync [owner/repo]`, `al backup` |
 | Brewfile 取り込み | 既存 Brewfile を al の管理下に登録 | `al import Brewfile --prf <profile>` |
 | 設定 | デフォルト profile / provider / stage、バックアップ先、エイリアス | `al config set/show`, `al config alias list` |
@@ -87,13 +88,17 @@ Profile に `promote_to` を設定すると、パッケージを trial から st
 
 パッケージごとのシェル設定を `~/.al/shell.d/<パッケージ識別子>/` に置き、`al activate` の出力でまとめて source する。読み込み順は after で制御。有効/無効は `al package shell enable/disable`。
 
+### bootstrap
+
+新規 PC のセットアップで、al の他の機能では自動化できないワンオフのシェル実行を行うためのスクリプト。`~/.al/bootstrap/script.sh` に 1 本のスクリプトが保存される。`al bootstrap add` で作成、`edit` で編集、`remove` で削除、`show` で内容表示。sync / backup で他マシンと共有可能。
+
 ### extends
 
 Profile が別の profile を継承する指定。例: `work` が `core.stable` を extends する場合、`al sync --profile work` では work と core.stable のパッケージが適用される。
 
 ### sync と backup
 
-- **sync**: `~/.al` が無い場合は指定した `owner/repo` を clone してから、provider の確保・パッケージのインストール・link.d の symlink 適用を行う。既に存在する場合は適用のみ。`--all` で AutoSync 有効な profile をすべて対象、`--profile <name>` で指定 profile とその extends のみ。`--pkg-only` / `--link-only` でパッケージのみ / link のみ。
+- **sync**: `~/.al` が無い場合は指定した `owner/repo` を clone してから、provider の確保・パッケージのインストール・link.d の symlink 適用を行う。既に存在する場合は適用のみ。最後に `~/.al/bootstrap/script.sh` が存在すれば実行する。`--all` で AutoSync 有効な profile をすべて対象、`--profile <name>` で指定 profile とその extends のみ。`--pkg-only` / `--link-only` でパッケージのみ / link のみ。
 - **backup**: `~/.al` を commit して GitHub に push。`--init` でリポジトリが無ければ作成。`--repo owner/repo` で保存先を指定。デフォルトは `gh` で取得したユーザの `dotal`。
 
 ---
@@ -134,7 +139,7 @@ al update
 |----------|------|
 | `al init` | 初回セットアップ（profile core, provider brew, デフォルト設定） |
 | `al activate zsh` / `bash` | シェル用コードを出力。`.zshrc` 等に `eval "$(al activate zsh)"` を追加する |
-| `al sync [owner/repo]` | `~/.al` が無ければ clone し、provider/パッケージ/link を適用 |
+| `al sync [owner/repo]` | `~/.al` が無ければ clone し、provider/パッケージ/link を適用。最後に bootstrap スクリプトがあれば実行 |
 | `al backup` | `~/.al` を commit して GitHub に push（`--init` でリポジトリ作成） |
 | `al update` | al 本体を最新版に更新 |
 | `al upgrade` | 全 provider と全パッケージをアップグレード（`-y` で確認スキップ） |
@@ -193,6 +198,17 @@ al update
 | `al link list` | 一覧 |
 | `al link remove <名前>` | 削除（オプションで実体をユーザパスへ copy-back） |
 | `al link edit <名前>` | ユーザパスなどの編集 |
+
+### al bootstrap
+
+新規 PC のセットアップで、al の他の機能では自動化できないワンオフのシェル実行用。スクリプトは `~/.al/bootstrap/script.sh` に保存される。
+
+| サブコマンド | 説明 |
+|--------------|------|
+| `al bootstrap add` | スクリプトを作成（未作成時のみ初期内容で作成） |
+| `al bootstrap edit` | EDITOR でスクリプトを編集（未作成時は add と同様に作成してから開く） |
+| `al bootstrap remove` | スクリプトを削除 |
+| `al bootstrap show` | スクリプト内容を表示 |
 
 ---
 

--- a/cmd/bootstrap/add.go
+++ b/cmd/bootstrap/add.go
@@ -1,0 +1,35 @@
+package bootstrap
+
+import (
+	"fmt"
+
+	"github.com/kkato1030/al/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewAddCmd creates the bootstrap add command
+func NewAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Create the bootstrap script",
+		Long:  "Create ~/.al/bootstrap/script.sh with default content if it does not exist. Does nothing if the script already exists.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAdd()
+		},
+	}
+	return cmd
+}
+
+func runAdd() error {
+	path, created, err := config.EnsureBootstrapScript()
+	if err != nil {
+		return err
+	}
+	if created {
+		fmt.Printf("Created bootstrap script: %s\n", path)
+	} else {
+		fmt.Printf("Bootstrap script already exists: %s\n", path)
+	}
+	return nil
+}

--- a/cmd/bootstrap/edit.go
+++ b/cmd/bootstrap/edit.go
@@ -1,0 +1,47 @@
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/kkato1030/al/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewEditCmd creates the bootstrap edit command
+func NewEditCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit the bootstrap script in EDITOR",
+		Long:  "Open ~/.al/bootstrap/script.sh in EDITOR (default: vim). Creates the script with default content if it does not exist.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEdit()
+		},
+	}
+	return cmd
+}
+
+func runEdit() error {
+	_, _, err := config.EnsureBootstrapScript()
+	if err != nil {
+		return err
+	}
+	path, err := config.GetBootstrapScriptPath()
+	if err != nil {
+		return err
+	}
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vim"
+	}
+	editorCmd := exec.Command(editor, path)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+	if err := editorCmd.Run(); err != nil {
+		return fmt.Errorf("running %s: %w", editor, err)
+	}
+	return nil
+}

--- a/cmd/bootstrap/remove.go
+++ b/cmd/bootstrap/remove.go
@@ -1,0 +1,30 @@
+package bootstrap
+
+import (
+	"fmt"
+
+	"github.com/kkato1030/al/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewRemoveCmd creates the bootstrap remove command
+func NewRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Delete the bootstrap script",
+		Long:  "Delete ~/.al/bootstrap/script.sh. The bootstrap directory is left in place.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRemove()
+		},
+	}
+	return cmd
+}
+
+func runRemove() error {
+	if err := config.RemoveBootstrapScript(); err != nil {
+		return err
+	}
+	fmt.Println("Removed bootstrap script")
+	return nil
+}

--- a/cmd/bootstrap/root.go
+++ b/cmd/bootstrap/root.go
@@ -1,0 +1,19 @@
+package bootstrap
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewBootstrapCmd creates the bootstrap command
+func NewBootstrapCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Manage bootstrap script for new PC setup",
+		Long:  "One-off shell script for new PC setup. Script is stored at ~/.al/bootstrap/script.sh. Use add to create, edit to open in EDITOR, remove to delete, show to print content.",
+	}
+	cmd.AddCommand(NewAddCmd())
+	cmd.AddCommand(NewEditCmd())
+	cmd.AddCommand(NewRemoveCmd())
+	cmd.AddCommand(NewShowCmd())
+	return cmd
+}

--- a/cmd/bootstrap/show.go
+++ b/cmd/bootstrap/show.go
@@ -1,0 +1,31 @@
+package bootstrap
+
+import (
+	"os"
+
+	"github.com/kkato1030/al/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewShowCmd creates the bootstrap show command
+func NewShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show the bootstrap script content",
+		Long:  "Print the content of ~/.al/bootstrap/script.sh to stdout.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow()
+		},
+	}
+	return cmd
+}
+
+func runShow() error {
+	data, err := config.ReadBootstrapScript()
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(data)
+	return err
+}

--- a/cmd/package/add.go
+++ b/cmd/package/add.go
@@ -75,7 +75,7 @@ func NewPackageAddCmd() *cobra.Command {
 			if profileConfig == nil {
 				return fmt.Errorf("profile '%s' does not exist", finalProfile)
 			}
-			
+
 			// Update finalProfile to the actual profile name found
 			finalProfile = profileConfig.Name
 
@@ -142,7 +142,7 @@ func findProfileWithFallback(fullProfileName, stageFlag string) (*config.Profile
 		if err != nil {
 			return nil, err
 		}
-		
+
 		// Try to find profile with just profile_name (no stage)
 		profileConfig, err = config.GetProfile(profileName)
 		if err != nil {
@@ -184,7 +184,7 @@ func runPackageAdd(packageName, providerName, profile, version, description, pac
 	if profileConfig == nil {
 		return fmt.Errorf("profile '%s' does not exist", profile)
 	}
-	
+
 	// Update profile to the actual profile name found
 	profile = profileConfig.Name
 
@@ -362,7 +362,7 @@ func runPackageAddInteractive(packageName, provider, profile, stage, version, de
 	if err != nil {
 		return fmt.Errorf("error building profile name: %w", err)
 	}
-	
+
 	// Verify profile exists with fallback
 	profileConfig, err := findProfileWithFallback(finalProfile, stage)
 	if err != nil {
@@ -371,7 +371,7 @@ func runPackageAddInteractive(packageName, provider, profile, stage, version, de
 	if profileConfig == nil {
 		return fmt.Errorf("profile '%s' does not exist", finalProfile)
 	}
-	
+
 	// Update profile to the actual profile name found
 	profile = profileConfig.Name
 

--- a/cmd/package/import.go
+++ b/cmd/package/import.go
@@ -151,7 +151,6 @@ func NewPackageImportCmd() *cobra.Command {
 					continue
 				}
 
-
 				if install {
 					if e.Provider == "brew" && brewProv != nil {
 						if err := brewProv.InstallPackage(e.ID); err != nil {

--- a/cmd/package/list.go
+++ b/cmd/package/list.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	profileLineChar   = "━"  // U+2501 BOX DRAWINGS HEAVY HORIZONTAL
+	profileLineChar   = "━"   // U+2501 BOX DRAWINGS HEAVY HORIZONTAL
 	profileLineLead   = "━━ " // leading "━━ " before profile name
 	profileLineTail   = " ━"  // " ━" after profile name before fill
-	maxProfileLineLen = 48   // cap line length so it doesn't stretch across wide terminals
+	maxProfileLineLen = 48    // cap line length so it doesn't stretch across wide terminals
 )
 
 // NewPackageListCmd creates the package list command

--- a/cmd/package/upgrade.go
+++ b/cmd/package/upgrade.go
@@ -149,7 +149,7 @@ func runPackageUpgrade(packageName string) error {
 		for _, pkg := range matchingPackages {
 			fmt.Printf("  - %s (%s:%s) [profile: %s]\n", pkg.Name, pkg.Provider, pkg.ID, pkg.Profile)
 		}
-		fmt.Println("Upgrading all matching packages...\n")
+		fmt.Println("Upgrading all matching packages...")
 	}
 
 	// Upgrade each matching package

--- a/cmd/profile/add.go
+++ b/cmd/profile/add.go
@@ -539,4 +539,3 @@ func selectPackageDuplicationUI() (string, error) {
 
 	return model.GetSelected(), nil
 }
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	bootstrapcmd "github.com/kkato1030/al/cmd/bootstrap"
 	configcmd "github.com/kkato1030/al/cmd/config"
 	linkcmd "github.com/kkato1030/al/cmd/link"
 	packagecmd "github.com/kkato1030/al/cmd/package"
@@ -53,6 +54,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.AddCommand(NewUpdateCmd())
 	rootCmd.AddCommand(NewUpgradeCmd())
 	rootCmd.AddCommand(NewActivateCmd())
+	rootCmd.AddCommand(bootstrapcmd.NewBootstrapCmd())
 	rootCmd.AddCommand(configcmd.NewConfigCmd())
 	rootCmd.AddCommand(linkcmd.NewLinkCmd())
 	rootCmd.AddCommand(provider.NewProviderCmd())

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -143,6 +144,10 @@ func runSync(dryRun, all bool, profileName string, usePrivate bool, pkgOnly bool
 			links, _ := config.ListLinks("", "")
 			fmt.Printf("[dry-run] Would apply %d link(s)\n", len(links))
 		}
+		exists, _ := config.BootstrapScriptExists()
+		if exists {
+			fmt.Println("[dry-run] Would run bootstrap script at the end")
+		}
 		return nil
 	}
 
@@ -209,6 +214,31 @@ func runSync(dryRun, all bool, profileName string, usePrivate bool, pkgOnly bool
 			if err := config.EnsureLinkSymlink(&entry, entryDir); err != nil {
 				return fmt.Errorf("link %s: %w", entry.Name, err)
 			}
+		}
+	}
+
+	// Run bootstrap script if present
+	exists, err := config.BootstrapScriptExists()
+	if err != nil {
+		return fmt.Errorf("bootstrap check: %w", err)
+	}
+	if exists {
+		scriptPath, err := config.GetBootstrapScriptPath()
+		if err != nil {
+			return fmt.Errorf("bootstrap path: %w", err)
+		}
+		bootstrapDir, err := config.GetBootstrapDir()
+		if err != nil {
+			return fmt.Errorf("bootstrap dir: %w", err)
+		}
+		fmt.Println("\nRunning bootstrap script...")
+		cmd := exec.Command(scriptPath)
+		cmd.Dir = bootstrapDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("bootstrap script: %w", err)
 		}
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -25,8 +25,8 @@ const (
 )
 
 type Release struct {
-	TagName string `json:"tag_name"`
-	Name    string `json:"name"`
+	TagName string  `json:"tag_name"`
+	Name    string  `json:"name"`
 	Assets  []Asset `json:"assets"`
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	providercmd "github.com/kkato1030/al/cmd/provider"
 	packagecmd "github.com/kkato1030/al/cmd/package"
+	providercmd "github.com/kkato1030/al/cmd/provider"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const bootstrapScriptName = "script.sh"
+
+// DefaultBootstrapScriptContent is the initial content when creating the bootstrap script.
+const DefaultBootstrapScriptContent = "#!/usr/bin/env bash\n# Bootstrap script for new PC setup. Edit with: al bootstrap edit\nset -euo pipefail\n\n"
+
+// GetBootstrapDir returns the path to ~/.al/bootstrap/
+func GetBootstrapDir() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "bootstrap"), nil
+}
+
+// GetBootstrapScriptPath returns the path to ~/.al/bootstrap/script.sh
+func GetBootstrapScriptPath() (string, error) {
+	dir, err := GetBootstrapDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, bootstrapScriptName), nil
+}
+
+// BootstrapScriptExists returns true if the bootstrap script file exists.
+func BootstrapScriptExists() (bool, error) {
+	path, err := GetBootstrapScriptPath()
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// EnsureBootstrapScript creates the bootstrap directory and script.sh with default content if it does not exist.
+// Returns the script path and whether the file was created (true) or already existed (false).
+func EnsureBootstrapScript() (path string, created bool, err error) {
+	dir, err := GetBootstrapDir()
+	if err != nil {
+		return "", false, err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", false, fmt.Errorf("creating bootstrap dir: %w", err)
+	}
+	path = filepath.Join(dir, bootstrapScriptName)
+	_, statErr := os.Stat(path)
+	if statErr == nil {
+		return path, false, nil
+	}
+	if !os.IsNotExist(statErr) {
+		return "", false, statErr
+	}
+	if err := os.WriteFile(path, []byte(DefaultBootstrapScriptContent), 0755); err != nil {
+		return "", false, fmt.Errorf("writing bootstrap script: %w", err)
+	}
+	return path, true, nil
+}
+
+// ReadBootstrapScript returns the content of the bootstrap script, or error if it does not exist.
+func ReadBootstrapScript() ([]byte, error) {
+	path, err := GetBootstrapScriptPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("bootstrap script not found (run 'al bootstrap add' to create)")
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+// RemoveBootstrapScript deletes the bootstrap script file.
+// The bootstrap directory is left in place (empty or not).
+func RemoveBootstrapScript() error {
+	path, err := GetBootstrapScriptPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("bootstrap script not found")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,7 +155,7 @@ func GetDefaultAliases() map[string]string {
 	return map[string]string{
 		"promote":  "package move {args} --to package.promote_to",
 		"add":      "package add",
-		"remove":  "package remove",
+		"remove":   "package remove",
 		"list":     "package list",
 		"register": "package add --provider manual",
 		"import":   "package import {args}",

--- a/internal/config/links.go
+++ b/internal/config/links.go
@@ -23,15 +23,15 @@ const (
 
 // LinkManifest represents the manifest for a link.d entry.
 type LinkManifest struct {
-	UserPath         string   `json:"user_path"`                   // absolute path (symlink location)
-	Type             LinkType `json:"type"`                        // file or dir
-	PackageID        string   `json:"package_id,omitempty"`         // optional package association
-	PackageProvider  string   `json:"package_provider,omitempty"` // optional package association
+	UserPath        string   `json:"user_path"`                  // absolute path (symlink location)
+	Type            LinkType `json:"type"`                       // file or dir
+	PackageID       string   `json:"package_id,omitempty"`       // optional package association
+	PackageProvider string   `json:"package_provider,omitempty"` // optional package association
 }
 
 // LinkEntry represents a link.d entry (manifest + name).
 type LinkEntry struct {
-	Name     string        // directory name under link.d (user-given name)
+	Name     string // directory name under link.d (user-given name)
 	Manifest *LinkManifest
 }
 

--- a/internal/config/packages.go
+++ b/internal/config/packages.go
@@ -10,8 +10,8 @@ import (
 
 // PackageConfig represents a package configuration
 type PackageConfig struct {
-	ID          string    `json:"id"`           // required: brew="{formula,cask,tap}:<package_name>", mas="<app_id>"
-	Name        string    `json:"name"`          // 表示用の名前（brewではidと同じ、masでは任意）
+	ID          string    `json:"id"`   // required: brew="{formula,cask,tap}:<package_name>", mas="<app_id>"
+	Name        string    `json:"name"` // 表示用の名前（brewではidと同じ、masでは任意）
 	Provider    string    `json:"provider"`
 	Profile     string    `json:"profile"`
 	Version     string    `json:"version,omitempty"`

--- a/internal/config/shell.go
+++ b/internal/config/shell.go
@@ -14,8 +14,8 @@ const shellManifestFilename = ".manifest.json"
 // ShellManifest represents the manifest for a package's shell.d directory.
 // It holds load order (after) and whether this package's shell is enabled for `al activate`.
 type ShellManifest struct {
-	After   string `json:"after,omitempty"`   // package dir name that this should load after
-	Enabled bool   `json:"enabled"`           // whether to source in `al activate`
+	After   string `json:"after,omitempty"` // package dir name that this should load after
+	Enabled bool   `json:"enabled"`         // whether to source in `al activate`
 }
 
 // GetShellDir returns the path to ~/.al/shell.d/

--- a/internal/config/templates.go
+++ b/internal/config/templates.go
@@ -244,7 +244,7 @@ func ApplyTemplate(template *ProfileTemplate, profileName string) ([]ProfileConf
 
 		// Build extends array
 		newExtends := make([]string, 0)
-		
+
 		// Add <default_profile> at the beginning if default_profile is set and not the same as the profile being created
 		if defaultProfile != "" {
 			// Parse the profile name to get profile_name part
@@ -252,7 +252,7 @@ func ApplyTemplate(template *ProfileTemplate, profileName string) ([]ProfileConf
 			if err != nil {
 				return nil, fmt.Errorf("error parsing profile name '%s': %w", newProfile.Name, err)
 			}
-			
+
 			// Only add if default_profile is different from the profile_name part
 			if defaultProfile != profileNamePart {
 				newExtends = append(newExtends, fmt.Sprintf("<default_profile>"))

--- a/internal/ui/profile.go
+++ b/internal/ui/profile.go
@@ -140,12 +140,12 @@ func NewOrderedMultiSelectModel(items []config.ProfileConfig, title, excludeName
 	}
 
 	return &OrderedMultiSelectModel{
-		items:       filtered,
-		selected:    make(map[int]int),
-		nextOrder:   1,
-		cursor:      0,
-		title:       title,
-		excludeName: excludeName,
+		items:        filtered,
+		selected:     make(map[int]int),
+		nextOrder:    1,
+		cursor:       0,
+		title:        title,
+		excludeName:  excludeName,
 		selectedKeys: []int{},
 	}
 }


### PR DESCRIPTION
## 概要
Issue #43 の実装です。

- **al bootstrap**: 新規 PC セットアップ用のワンオフシェルスクリプトを `~/.al/bootstrap/script.sh` で管理
  - `al bootstrap add`: スクリプトを作成（未作成時のみ）
  - `al bootstrap edit`: EDITOR で編集
  - `al bootstrap remove`: 削除
  - `al bootstrap show`: 内容表示
- デフォルトスクリプトは `set -euo pipefail`
- **al sync**: パッケージ・link 適用の最後に bootstrap スクリプトが存在すれば実行するように変更
- README に bootstrap の機能一覧・概念・コマンドリファレンスを追加。sync の説明を更新
- `cmd/package/upgrade.go`: go vet の冗長 newline 警告を修正

Closes #43

Made with [Cursor](https://cursor.com)