### PR TITLE
feat: add profile review_days and al review (remove/promote/postpone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ eval "$(al activate bash)"  # bash
 | 機能 | 説明 | 主なコマンド |
 |------|------|----------------|
 | パッケージ管理 | Homebrew / mas の追加・削除・昇格・一覧・アップグレード | `al add`, `al remove`, `al promote`, `al list`, `al upgrade` |
+| trial レビュー | trial のレビュー期限切れパッケージの対話的解決（remove / promote / postpone） | `al review` |
 | Profile | 用途別の環境分離（例: work / private） | `al profile add`, `al profile list`, `al profile show` |
 | link.d | dotfiles を `~/.al/link.d/` に集約し、ユーザパスを symlink に | `al link add/list/remove/edit` |
 | shell.d | パッケージごとのシェルスニペットと読み込み順の管理 | `al package shell show/set/edit/enable/disable` |
@@ -75,6 +76,10 @@ eval "$(al activate bash)"  # bash
 ### promote（昇格）
 
 Profile に `promote_to` を設定すると、パッケージを trial から stable などへ移動できる。`al package move <name> --to <profile>` またはエイリアス `al promote <name>`（パッケージが属する profile の promote_to へ移動）。同一パッケージ（同一 ID・provider）が trial と stable の両方に同時に存在することはない。
+
+### trial のレビュー期限（review）
+
+Profile に `review_days` を設定すると、その profile のパッケージがレビュー対象になる。`review_days` が無い profile はレビュー対象外。パッケージの `review_by`（レビュー期限日時）が無いか期限を過ぎていれば「期限切れ」として扱う。`al activate` 実行時に期限切れがあると stderr に一覧と「`al review` で解決」の案内を表示する。`al review` では各パッケージについて **remove**（使わなかったので削除）、**promote**（stable へ昇格）、**postpone**（同じ日数だけ延期＝`review_by` を今＋review_days に更新）のいずれかを選べる。postpone 時は「本当に？ それが必要なの？」の確認プロンプトが出る。
 
 ### Provider
 
@@ -138,7 +143,8 @@ al update
 | コマンド | 説明 |
 |----------|------|
 | `al init` | 初回セットアップ（profile core, provider brew, デフォルト設定） |
-| `al activate zsh` / `bash` | シェル用コードを出力。`.zshrc` 等に `eval "$(al activate zsh)"` を追加する |
+| `al activate zsh` / `bash` | シェル用コードを出力。`.zshrc` 等に `eval "$(al activate zsh)"` を追加する。trial のレビュー期限切れがあると stderr に案内を表示 |
+| `al review` | レビュー期限切れの trial パッケージを対話で解決（remove / promote / postpone） |
 | `al sync [owner/repo]` | `~/.al` が無ければ clone し、provider/パッケージ/link を適用。最後に bootstrap スクリプトがあれば実行 |
 | `al backup` | `~/.al` を commit して GitHub に push（`--init` でリポジトリ作成） |
 | `al update` | al 本体を最新版に更新 |

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kkato1030/al/internal/config"
 	"github.com/spf13/cobra"
@@ -20,6 +21,15 @@ func NewActivateCmd() *cobra.Command {
 }
 
 func runActivate(cmd *cobra.Command, args []string) error {
+	// Show overdue packages notice on stderr (so eval still gets clean script on stdout)
+	if overdue, err := config.GetOverduePackages(); err == nil && len(overdue) > 0 {
+		fmt.Fprintln(os.Stderr, "Review overdue: the following packages need a decision (remove / promote / postpone).")
+		for _, pkg := range overdue {
+			fmt.Fprintf(os.Stderr, "  - %s (profile: %s, provider: %s)\n", pkg.Name, pkg.Profile, pkg.Provider)
+		}
+		fmt.Fprintln(os.Stderr, "Run 'al review' to resolve.")
+	}
+
 	shell := args[0]
 	ext, err := shellExt(shell)
 	if err != nil {

--- a/cmd/package/add.go
+++ b/cmd/package/add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/kkato1030/al/internal/config"
@@ -291,6 +292,10 @@ func runPackageAdd(packageName, providerName, profile, version, description, pac
 		Profile:     profile,
 		Version:     version,
 		Description: description,
+	}
+	if days, hasReview, _ := config.GetReviewDays(profile); hasReview && days > 0 {
+		reviewBy := time.Now().AddDate(0, 0, days)
+		pkg.ReviewBy = &reviewBy
 	}
 
 	// Add or update package in config

--- a/cmd/package/import.go
+++ b/cmd/package/import.go
@@ -171,6 +171,10 @@ func NewPackageImportCmd() *cobra.Command {
 					Profile:     finalProfile,
 					InstalledAt: time.Now(),
 				}
+				if days, hasReview, _ := config.GetReviewDays(finalProfile); hasReview && days > 0 {
+					reviewBy := time.Now().AddDate(0, 0, days)
+					pkg.ReviewBy = &reviewBy
+				}
 				if overwrite {
 					if err := config.AddOrUpdatePackage(pkg); err != nil {
 						return fmt.Errorf("add or update package %s: %w", e.ID, err)

--- a/cmd/package/move.go
+++ b/cmd/package/move.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kkato1030/al/internal/config"
 	"github.com/spf13/cobra"
@@ -153,6 +154,10 @@ func movePackage(pkg config.PackageConfig, toProfile string) error {
 		Description: pkg.Description,
 		InstalledAt: pkg.InstalledAt,
 	}
+	if days, hasReview, _ := config.GetReviewDays(toProfile); hasReview && days > 0 {
+		reviewBy := time.Now().AddDate(0, 0, days)
+		newPkg.ReviewBy = &reviewBy
+	}
 
 	if err := config.AddOrUpdatePackage(newPkg); err != nil {
 		return fmt.Errorf("error adding package to target profile: %w", err)
@@ -160,4 +165,9 @@ func movePackage(pkg config.PackageConfig, toProfile string) error {
 
 	fmt.Printf("Package '%s' (ID: %s) has been successfully moved from profile '%s' to profile '%s'\n", pkg.Name, pkg.ID, pkg.Profile, toProfile)
 	return nil
+}
+
+// RunPackageMoveFromConfig moves a package to another profile (used by al review promote).
+func RunPackageMoveFromConfig(pkg config.PackageConfig, toProfile string) error {
+	return movePackage(pkg, toProfile)
 }

--- a/cmd/package/remove.go
+++ b/cmd/package/remove.go
@@ -154,6 +154,11 @@ func runPackageRemove(packageName, providerName, profile string, keepShell, keep
 	return nil
 }
 
+// RunPackageRemoveFromConfig removes a package by config (used by al review).
+func RunPackageRemoveFromConfig(pkg config.PackageConfig, keepShell, keepLink bool) error {
+	return runPackageRemove(pkg.Name, pkg.Provider, pkg.Profile, keepShell, keepLink)
+}
+
 func runPackageRemoveInteractive(packageName, provider, profile string, keepShell, keepLink bool) error {
 	// Get package name
 	fmt.Printf("Package name: %s\n", packageName)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	packagecmd "github.com/kkato1030/al/cmd/package"
+	"github.com/kkato1030/al/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewReviewCmd creates the review command
+func NewReviewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "review",
+		Short: "Resolve overdue packages (remove / promote / postpone)",
+		Long:  "List packages past their review deadline and choose remove (uninstall), promote (move to stable), or postpone (extend review by same period). Postpone shows a confirmation prompt.",
+		Args:  cobra.NoArgs,
+		RunE:  runReview,
+	}
+	return cmd
+}
+
+func runReview(cmd *cobra.Command, args []string) error {
+	overdue, err := config.GetOverduePackages()
+	if err != nil {
+		return fmt.Errorf("get overdue packages: %w", err)
+	}
+	if len(overdue) == 0 {
+		fmt.Println("No packages overdue for review.")
+		return nil
+	}
+
+	fmt.Printf("Review overdue: %d package(s). Decide for each: remove / promote / postpone.\n\n", len(overdue))
+	scanner := bufio.NewScanner(os.Stdin)
+
+	for _, pkg := range overdue {
+		resolved := false
+		for !resolved {
+			fmt.Printf("Package: %s (profile: %s, provider: %s)\n", pkg.Name, pkg.Profile, pkg.Provider)
+			fmt.Print("  [r]emove  [p]romote  [s]postpone: ")
+			if !scanner.Scan() {
+				return scanner.Err()
+			}
+			choice := strings.TrimSpace(strings.ToLower(scanner.Text()))
+			if choice == "" {
+				continue
+			}
+
+			switch choice {
+			case "r", "remove":
+				if err := packagecmd.RunPackageRemoveFromConfig(pkg, false, false); err != nil {
+					return fmt.Errorf("remove %s: %w", pkg.Name, err)
+				}
+				resolved = true
+			case "p", "promote":
+				prof, err := config.GetProfile(pkg.Profile)
+				if err != nil || prof == nil {
+					return fmt.Errorf("get profile %s: %w", pkg.Profile, err)
+				}
+				if prof.PromoteTo == "" {
+					return fmt.Errorf("profile %s has no promote_to (cannot promote)", pkg.Profile)
+				}
+				if err := packagecmd.RunPackageMoveFromConfig(pkg, prof.PromoteTo); err != nil {
+					return fmt.Errorf("promote %s: %w", pkg.Name, err)
+				}
+				resolved = true
+			default:
+				// postpone (default; "s", "postpone", or any other input)
+				fmt.Print("  Really? Do you really need it? [y/N]: ")
+				if !scanner.Scan() {
+					return scanner.Err()
+				}
+				confirm := strings.TrimSpace(strings.ToLower(scanner.Text()))
+				if confirm != "y" && confirm != "yes" {
+					fmt.Println("  Back to choice.")
+					continue
+				}
+				days, hasReview, err := config.GetReviewDays(pkg.Profile)
+				if err != nil || !hasReview || days <= 0 {
+					return fmt.Errorf("profile %s has no review_days", pkg.Profile)
+				}
+				reviewBy := time.Now().AddDate(0, 0, days)
+				if err := config.SetPackageReviewBy(pkg.ID, pkg.Provider, pkg.Profile, reviewBy); err != nil {
+					return fmt.Errorf("postpone %s: %w", pkg.Name, err)
+				}
+				fmt.Printf("  Review extended to %s.\n", reviewBy.Format("2006-01-02"))
+				resolved = true
+			}
+		}
+		fmt.Println()
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.AddCommand(NewUpdateCmd())
 	rootCmd.AddCommand(NewUpgradeCmd())
 	rootCmd.AddCommand(NewActivateCmd())
+	rootCmd.AddCommand(NewReviewCmd())
 	rootCmd.AddCommand(bootstrapcmd.NewBootstrapCmd())
 	rootCmd.AddCommand(configcmd.NewConfigCmd())
 	rootCmd.AddCommand(linkcmd.NewLinkCmd())

--- a/internal/config/packages.go
+++ b/internal/config/packages.go
@@ -17,6 +17,8 @@ type PackageConfig struct {
 	Version     string    `json:"version,omitempty"`
 	InstalledAt time.Time `json:"installed_at"`
 	Description string    `json:"description,omitempty"`
+	// ReviewBy is the deadline for reviewing this package. Used with profile review_days. nil or past = review target.
+	ReviewBy *time.Time `json:"review_by,omitempty"`
 }
 
 // PackagesConfig represents the collection of package configurations
@@ -178,4 +180,53 @@ func GetPackagesConfigPath() (string, error) {
 	}
 
 	return filepath.Join(configDir, "packages.json"), nil
+}
+
+// GetOverduePackages returns packages that are past their review deadline.
+// A package is overdue if its profile has review_days and either:
+// - the package has no review_by set, or
+// - review_by is in the past.
+func GetOverduePackages() ([]PackageConfig, error) {
+	cfg, err := LoadPackagesConfig()
+	if err != nil {
+		return nil, err
+	}
+	var out []PackageConfig
+	now := time.Now()
+	for _, pkg := range cfg.Packages {
+		_, hasReview, err := GetReviewDays(pkg.Profile)
+		if err != nil || !hasReview {
+			continue
+		}
+		overdue := false
+		if pkg.ReviewBy == nil {
+			overdue = true
+		} else if !now.Before(*pkg.ReviewBy) {
+			overdue = true
+		}
+		if overdue {
+			out = append(out, pkg)
+		}
+	}
+	return out, nil
+}
+
+// SetPackageReviewBy sets the review_by (deadline) field of a package (e.g. after postpone).
+func SetPackageReviewBy(id, provider, profile string, reviewBy time.Time) error {
+	cfg, err := LoadPackagesConfig()
+	if err != nil {
+		return err
+	}
+	found := false
+	for i := range cfg.Packages {
+		if cfg.Packages[i].ID == id && cfg.Packages[i].Provider == provider && cfg.Packages[i].Profile == profile {
+			cfg.Packages[i].ReviewBy = &reviewBy
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("package with id '%s' with provider '%s' in profile '%s' not found", id, provider, profile)
+	}
+	return SavePackagesConfig(cfg)
 }

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -18,6 +18,8 @@ type ProfileConfig struct {
 	PromoteTo          string   `json:"promote_to,omitempty"`
 	PackageDuplication string   `json:"package_duplication,omitempty"`
 	AutoSync           *bool    `json:"auto_sync,omitempty"` // nil/true = include in "al sync" (default), false = exclude unless --profile
+	// ReviewDays is the number of days after which packages must be reviewed. nil or 0 = not a review target. Set to e.g. 30 to require review every 30 days (based on package reviewed_at).
+	ReviewDays *int `json:"review_days,omitempty"`
 }
 
 // ProfilesConfig represents the collection of profile configurations
@@ -253,6 +255,19 @@ func ResolveProfileWithExtends(name string) ([]string, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// GetReviewDays returns the review period in days for the profile, and whether review is required.
+// No review_days (nil or <= 0) → not a review target. Has review_days → packages use reviewed_at + review_days for due date.
+func GetReviewDays(profileName string) (days int, hasReview bool, err error) {
+	p, err := GetProfile(profileName)
+	if err != nil || p == nil {
+		return 0, false, err
+	}
+	if p.ReviewDays == nil || *p.ReviewDays <= 0 {
+		return 0, false, nil
+	}
+	return *p.ReviewDays, true, nil
 }
 
 // GetSyncTargetProfileNames returns profile names to sync based on mode.

--- a/internal/config/templates.go
+++ b/internal/config/templates.go
@@ -19,6 +19,8 @@ type TemplatesConfig struct {
 	Templates []ProfileTemplate `json:"templates"`
 }
 
+func intPtr(n int) *int { return &n }
+
 // GetDefaultTemplates returns the default templates embedded in the code
 func GetDefaultTemplates() []ProfileTemplate {
 	return []ProfileTemplate{
@@ -39,10 +41,11 @@ func GetDefaultTemplates() []ProfileTemplate {
 					Stage: "stable",
 				},
 				{
-					Name:      "<profile_name>.trial",
-					Stage:     "trial",
-					Extends:   []string{"<profile_name>"},
-					PromoteTo: "<profile_name>",
+					Name:       "<profile_name>.trial",
+					Stage:      "trial",
+					Extends:    []string{"<profile_name>"},
+					PromoteTo:  "<profile_name>",
+					ReviewDays: intPtr(30),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
Implements trial/review flow per **#49**.

- **Profile**: optional `review_days`. No `review_days` → not a review target.
- **Package**: `review_by` (deadline). Nil or past → overdue.
- **`al activate`**: when there are overdue packages, prints notice on stderr and suggests `al review`.
- **`al review`** (new command): for each overdue package, choose **remove** / **promote** / **postpone**.
  - Postpone: confirmation prompt ("Really? Do you really need it?"); if N, back to same package choice.
  - No default choice; no "trial" wording in messages.
- **add / import / move**: set `review_by = now + review_days` when the profile has `review_days`.
- **Templates**: trial profile in stable-trial template has `review_days: 30`.
- **README**: document review feature and `al review`.

Closes #49

Made with [Cursor](https://cursor.com)