### PR TITLE
Add unit tests for brewfile parser and config (Issue #51)

### DIFF
--- a/internal/brewfile/parser_test.go
+++ b/internal/brewfile/parser_test.go
@@ -1,0 +1,231 @@
+package brewfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		content  string
+		wantErr  bool
+		wantN    int
+		wantSkip int
+		check    func(t *testing.T, r *ParseResult)
+	}{
+		{
+			name:     "empty file",
+			content:  "",
+			wantN:    0,
+			wantSkip: 0,
+		},
+		{
+			name: "comments and empty lines only",
+			content: `
+# comment
+   
+# another
+`,
+			wantN:    0,
+			wantSkip: 0,
+		},
+		{
+			name:    "tap single",
+			content: `tap "homebrew/cask"`,
+			wantN:   1,
+			check: func(t *testing.T, r *ParseResult) {
+				if len(r.Entries) != 1 {
+					t.Fatalf("entries: got %d", len(r.Entries))
+				}
+				e := r.Entries[0]
+				if e.Provider != "brew" || e.ID != "tap:homebrew/cask" || e.Name != "homebrew/cask" {
+					t.Errorf("entry: provider=%q id=%q name=%q", e.Provider, e.ID, e.Name)
+				}
+			},
+		},
+		{
+			name:    "brew formula",
+			content: `brew "ruby"`,
+			wantN:   1,
+			check: func(t *testing.T, r *ParseResult) {
+				e := r.Entries[0]
+				if e.Provider != "brew" || e.ID != "formula:ruby" || e.Name != "ruby" {
+					t.Errorf("entry: provider=%q id=%q name=%q", e.Provider, e.ID, e.Name)
+				}
+			},
+		},
+		{
+			name:    "brew formula with version",
+			content: `brew "postgresql@16"`,
+			wantN:   1,
+			check: func(t *testing.T, r *ParseResult) {
+				e := r.Entries[0]
+				if e.ID != "formula:postgresql@16" {
+					t.Errorf("id: got %q", e.ID)
+				}
+			},
+		},
+		{
+			name:    "cask",
+			content: `cask "firefox"`,
+			wantN:   1,
+			check: func(t *testing.T, r *ParseResult) {
+				e := r.Entries[0]
+				if e.Provider != "brew" || e.ID != "cask:firefox" || e.Name != "firefox" {
+					t.Errorf("entry: provider=%q id=%q name=%q", e.Provider, e.ID, e.Name)
+				}
+			},
+		},
+		{
+			name:    "mas with id",
+			content: `mas "Slack", id: 803453959`,
+			wantN:   1,
+			check: func(t *testing.T, r *ParseResult) {
+				e := r.Entries[0]
+				if e.Provider != "mas" || e.ID != "803453959" || e.Name != "Slack" {
+					t.Errorf("entry: provider=%q id=%q name=%q", e.Provider, e.ID, e.Name)
+				}
+			},
+		},
+		{
+			name:     "vscode skipped",
+			content:  `vscode "editorconfig.editorconfig"`,
+			wantN:    0,
+			wantSkip: 1,
+			check: func(t *testing.T, r *ParseResult) {
+				if len(r.Skipped) != 1 || r.Skipped[0].Reason != "vscode" {
+					t.Errorf("skipped: %+v", r.Skipped)
+				}
+			},
+		},
+		{
+			name:     "mas without id skipped",
+			content:  `mas "Some App"`,
+			wantN:    0,
+			wantSkip: 1,
+			check: func(t *testing.T, r *ParseResult) {
+				if len(r.Skipped) != 1 {
+					t.Errorf("skipped: got %d", len(r.Skipped))
+				}
+			},
+		},
+		{
+			name: "mixed",
+			content: `tap "homebrew/cask"
+brew "ruby"
+# comment
+cask "firefox"
+mas "Slack", id: 803453959
+vscode "ext"
+`,
+			wantN:    4,
+			wantSkip: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, "Brewfile")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			r, err := ParseFile(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if len(r.Entries) != tt.wantN {
+				t.Errorf("entries: got %d, want %d", len(r.Entries), tt.wantN)
+			}
+			if len(r.Skipped) != tt.wantSkip {
+				t.Errorf("skipped: got %d, want %d", len(r.Skipped), tt.wantSkip)
+			}
+			if tt.check != nil {
+				tt.check(t, r)
+			}
+		})
+	}
+}
+
+func TestParseFile_NotFound(t *testing.T) {
+	_, err := ParseFile("/nonexistent/path/Brewfile")
+	if err == nil {
+		t.Error("ParseFile: expected error for nonexistent file")
+	}
+}
+
+func TestParseFile_Testdata(t *testing.T) {
+	// Use testdata/Brewfile if present (relative to package dir or repo root)
+	paths := []string{
+		"testdata/Brewfile",
+		"../../testdata/Brewfile",
+	}
+	var path string
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			path = p
+			break
+		}
+	}
+	if path == "" {
+		t.Skip("testdata/Brewfile not found")
+	}
+	r, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// testdata/Brewfile has: tap, brew x2, cask, mas, and vscode (skipped)
+	if len(r.Entries) < 4 {
+		t.Errorf("entries: got %d, want at least 4", len(r.Entries))
+	}
+	if len(r.Skipped) < 1 {
+		t.Errorf("skipped: got %d, want at least 1", len(r.Skipped))
+	}
+}
+
+func TestResolveBrewfilePath(t *testing.T) {
+	dir := t.TempDir()
+	customPath := filepath.Join(dir, "MyBrewfile")
+	if err := os.WriteFile(customPath, []byte("brew \"foo\""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("user path non-empty", func(t *testing.T) {
+		got, err := ResolveBrewfilePath(customPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != customPath {
+			t.Errorf("got %q, want %q", got, customPath)
+		}
+	})
+
+	t.Run("user path empty prefers current Brewfile", func(t *testing.T) {
+		// Run from dir that has Brewfile
+		withBrewfile := filepath.Join(dir, "sub")
+		if err := os.MkdirAll(withBrewfile, 0755); err != nil {
+			t.Fatal(err)
+		}
+		brewfilePath := filepath.Join(withBrewfile, "Brewfile")
+		if err := os.WriteFile(brewfilePath, []byte("brew \"a\""), 0644); err != nil {
+			t.Fatal(err)
+		}
+		origWd, _ := os.Getwd()
+		defer os.Chdir(origWd)
+		if err := os.Chdir(withBrewfile); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ResolveBrewfilePath("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "Brewfile" {
+			t.Errorf("got %q, want Brewfile", got)
+		}
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestGetDefaultAliases(t *testing.T) {
+	got := GetDefaultAliases()
+	want := map[string]string{
+		"promote":  "package move {args} --to package.promote_to",
+		"add":      "package add",
+		"remove":   "package remove",
+		"list":     "package list",
+		"register": "package add --provider manual",
+		"import":   "package import {args}",
+		"pkg":      "package",
+		"prf":      "profile",
+		"prv":      "provider",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetDefaultAliases() = %v, want %v", got, want)
+	}
+}
+
+func TestGetConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	got, err := GetConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != dir {
+		t.Errorf("GetConfigDir() = %q, want %q", got, dir)
+	}
+}
+
+func TestGetProvidersConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	got, err := GetProvidersConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "providers.json")
+	if got != want {
+		t.Errorf("GetProvidersConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	got, err := GetConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "config.json")
+	if got != want {
+		t.Errorf("GetConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadAppConfig_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	cfg, err := LoadAppConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadAppConfig() returned nil")
+	}
+	if cfg.DefaultProvider != "" || cfg.DefaultProfile != "" {
+		t.Errorf("expected empty config, got %+v", cfg)
+	}
+}
+
+func TestSaveAppConfig_LoadAppConfig_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	want := &AppConfig{
+		DefaultProvider: "brew",
+		DefaultProfile:  "default",
+		DefaultStage:    "stable",
+		BackupRepo:      "user/dotal",
+	}
+	if err := SaveAppConfig(want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadAppConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DefaultProvider != want.DefaultProvider ||
+		got.DefaultProfile != want.DefaultProfile ||
+		got.DefaultStage != want.DefaultStage ||
+		got.BackupRepo != want.BackupRepo {
+		t.Errorf("LoadAppConfig() = %+v, want %+v", got, want)
+	}
+}
+
+func setEnv(key, value string) func() {
+	old := os.Getenv(key)
+	os.Setenv(key, value)
+	return func() {
+		if old == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, old)
+		}
+	}
+}

--- a/internal/config/packages_test.go
+++ b/internal/config/packages_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAddPackage_GetOverduePackages(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Profile with review_days
+	days30 := 30
+	if err := SaveProfilesConfig(&ProfilesConfig{
+		Profiles: []ProfileConfig{{Name: "reviewed", ReviewDays: &days30}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add package without ReviewBy (should be overdue)
+	pkg := PackageConfig{
+		ID: "formula:ruby", Name: "ruby", Provider: "brew", Profile: "reviewed",
+		InstalledAt: time.Now(),
+	}
+	if err := AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+
+	overdue, err := GetOverduePackages()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(overdue) != 1 || overdue[0].ID != "formula:ruby" {
+		t.Errorf("GetOverduePackages() = %v", overdue)
+	}
+}
+
+func TestAddPackage_DuplicateError(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := PackageConfig{
+		ID: "formula:ruby", Name: "ruby", Provider: "brew", Profile: "default",
+		InstalledAt: time.Now(),
+	}
+	if err := AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+	err := AddPackage(pkg)
+	if err == nil {
+		t.Error("AddPackage duplicate should return error")
+	}
+}
+
+func TestAddOrUpdatePackage(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	installed := time.Now()
+	pkg := PackageConfig{
+		ID: "formula:foo", Name: "foo", Provider: "brew", Profile: "default",
+		InstalledAt: installed,
+	}
+	if err := AddOrUpdatePackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update same package
+	pkg.Description = "updated"
+	if err := AddOrUpdatePackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadPackagesConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Packages) != 1 || cfg.Packages[0].Description != "updated" {
+		t.Errorf("LoadPackagesConfig() = %+v", cfg.Packages)
+	}
+}
+
+func TestSamePackageInOtherProfile(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg1 := PackageConfig{ID: "formula:ruby", Name: "ruby", Provider: "brew", Profile: "default", InstalledAt: time.Now()}
+	pkg2 := PackageConfig{ID: "formula:ruby", Name: "ruby", Provider: "brew", Profile: "work", InstalledAt: time.Now()}
+	if err := AddPackage(pkg1); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddPackage(pkg2); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := SamePackageInOtherProfile("formula:ruby", "brew", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("SamePackageInOtherProfile should be true (work profile has same package)")
+	}
+
+	ok, err = SamePackageInOtherProfile("formula:ruby", "brew", "work")
+	if err != nil || !ok {
+		t.Errorf("SamePackageInOtherProfile(work) = %v, %v", ok, err)
+	}
+
+	ok, err = SamePackageInOtherProfile("formula:nonexistent", "brew", "default")
+	if err != nil || ok {
+		t.Errorf("nonexistent: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRemovePackage(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := PackageConfig{ID: "formula:bar", Name: "bar", Provider: "brew", Profile: "default", InstalledAt: time.Now()}
+	if err := AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemovePackage("formula:bar", "brew", "default"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := LoadPackagesConfig()
+	if len(cfg.Packages) != 0 {
+		t.Errorf("packages after remove: %v", cfg.Packages)
+	}
+
+	err := RemovePackage("formula:nonexistent", "brew", "default")
+	if err == nil {
+		t.Error("RemovePackage nonexistent should return error")
+	}
+}
+
+func TestSetPackageReviewBy(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg := PackageConfig{ID: "formula:baz", Name: "baz", Provider: "brew", Profile: "default", InstalledAt: time.Now()}
+	if err := AddPackage(pkg); err != nil {
+		t.Fatal(err)
+	}
+
+	reviewBy := time.Now().Add(7 * 24 * time.Hour)
+	if err := SetPackageReviewBy("formula:baz", "brew", "default", reviewBy); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := LoadPackagesConfig()
+	if len(cfg.Packages) != 1 || cfg.Packages[0].ReviewBy == nil {
+		t.Errorf("ReviewBy not set: %+v", cfg.Packages[0])
+	}
+
+	err := SetPackageReviewBy("formula:nonexistent", "brew", "default", reviewBy)
+	if err == nil {
+		t.Error("SetPackageReviewBy nonexistent should return error")
+	}
+}
+
+func TestLoadPackagesConfig_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	// No packages.json
+	cfg, err := LoadPackagesConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg == nil || len(cfg.Packages) != 0 {
+		t.Errorf("LoadPackagesConfig() = %v", cfg)
+	}
+}
+
+func TestGetPackagesConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	got, err := GetPackagesConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "packages.json")
+	if got != want {
+		t.Errorf("GetPackagesConfigPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -1,0 +1,337 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestValidateProfileName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"simple", "default", false},
+		{"with stage", "work.stable", false},
+		{"with hyphen", "my-profile", false},
+		{"with underscore", "my_profile", false},
+		{"with hash", "dev#1", false},
+		{"with at", "user@host", false},
+		{"with dot", "a.b", false},
+		{"invalid space", "has space", true},
+		{"invalid slash", "has/slash", true},
+		{"invalid colon", "has:colon", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProfileName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProfileName(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseProfileName(t *testing.T) {
+	tests := []struct {
+		name        string
+		fullName    string
+		wantProfile string
+		wantStage   string
+		wantErr     bool
+	}{
+		{"no stage", "default", "default", "", false},
+		{"with stage", "work.stable", "work", "stable", false},
+		{"empty", "", "", "", true},
+		{"invalid char", "has space", "", "", true},
+		{"dot only stage", "a.b", "a", "b", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, stage, err := ParseProfileName(tt.fullName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseProfileName() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if profile != tt.wantProfile || stage != tt.wantStage {
+				t.Errorf("ParseProfileName() = %q, %q, want %q, %q", profile, stage, tt.wantProfile, tt.wantStage)
+			}
+		})
+	}
+}
+
+func TestBuildProfileName(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		stage   string
+		want    string
+		wantErr bool
+	}{
+		{"no stage", "default", "", "default", false},
+		{"with stage", "work", "stable", "work.stable", false},
+		{"invalid profile", "", "stable", "", true},
+		{"invalid stage", "work", "bad stage", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildProfileName(tt.profile, tt.stage)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("BuildProfileName() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("BuildProfileName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAutoSyncEnabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	tests := []struct {
+		name string
+		p    ProfileConfig
+		want bool
+	}{
+		{"nil AutoSync", ProfileConfig{Name: "a", AutoSync: nil}, true},
+		{"true AutoSync", ProfileConfig{Name: "a", AutoSync: &trueVal}, true},
+		{"false AutoSync", ProfileConfig{Name: "a", AutoSync: &falseVal}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAutoSyncEnabled(tt.p); got != tt.want {
+				t.Errorf("IsAutoSyncEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProfilesConfig_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	trueVal := true
+	cfg := &ProfilesConfig{
+		Profiles: []ProfileConfig{
+			{Name: "default", Stage: "stable"},
+			{Name: "work.trial", Extends: []string{"default"}, AutoSync: &trueVal},
+		},
+	}
+	if err := SaveProfilesConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadProfilesConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Profiles) != len(cfg.Profiles) {
+		t.Fatalf("profiles: got %d, want %d", len(got.Profiles), len(cfg.Profiles))
+	}
+	for i := range cfg.Profiles {
+		if got.Profiles[i].Name != cfg.Profiles[i].Name {
+			t.Errorf("profile[%d].Name = %q, want %q", i, got.Profiles[i].Name, cfg.Profiles[i].Name)
+		}
+	}
+}
+
+func TestAddOrUpdateProfile_GetProfile_RemoveProfile(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	// Ensure config dir exists
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add profile
+	p := ProfileConfig{Name: "test", Description: "desc"}
+	if err := AddOrUpdateProfile(p); err != nil {
+		t.Fatal(err)
+	}
+	got, err := GetProfile("test")
+	if err != nil || got == nil {
+		t.Fatalf("GetProfile: err=%v got=%v", err, got)
+	}
+	if got.Description != "desc" {
+		t.Errorf("GetProfile: Description = %q", got.Description)
+	}
+
+	// Update same profile
+	p.Description = "updated"
+	if err := AddOrUpdateProfile(p); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = GetProfile("test")
+	if got.Description != "updated" {
+		t.Errorf("after update: Description = %q", got.Description)
+	}
+
+	// Remove profile
+	if err := RemoveProfile("test"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = GetProfile("test")
+	if got != nil {
+		t.Error("GetProfile after RemoveProfile should return nil")
+	}
+}
+
+func TestResolveProfileWithExtends(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	// Write profiles with extends
+	path := filepath.Join(dir, "profiles.json")
+	content := `{"profiles":[
+		{"name":"base"},
+		{"name":"mid","extends":["base"]},
+		{"name":"top","extends":["mid"]}
+	]}`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := ResolveProfileWithExtends("top")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"top", "mid", "base"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("ResolveProfileWithExtends(\"top\") = %v, want %v", names, want)
+	}
+
+	// Not found
+	_, err = ResolveProfileWithExtends("nonexistent")
+	if err == nil {
+		t.Error("ResolveProfileWithExtends(\"nonexistent\") expected error")
+	}
+}
+
+func TestGetSyncTargetProfileNames(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	path := filepath.Join(dir, "profiles.json")
+	content := `{"profiles":[
+		{"name":"a","auto_sync":true},
+		{"name":"b","auto_sync":false},
+		{"name":"c"}
+	]}`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("mode all", func(t *testing.T) {
+		names, err := GetSyncTargetProfileNames("all", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// a (true), c (nil = true); b (false) excluded
+		if len(names) != 2 {
+			t.Errorf("got %v", names)
+		}
+	})
+
+	t.Run("mode profile empty name", func(t *testing.T) {
+		_, err := GetSyncTargetProfileNames("profile", "")
+		if err == nil {
+			t.Error("expected error for empty profile name")
+		}
+	})
+
+	t.Run("mode profile", func(t *testing.T) {
+		names, err := GetSyncTargetProfileNames("profile", "a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(names) != 1 || names[0] != "a" {
+			t.Errorf("got %v", names)
+		}
+	})
+
+	t.Run("mode default no default_profile", func(t *testing.T) {
+		// config.json without default_profile
+		cfgPath := filepath.Join(dir, "config.json")
+		if err := os.WriteFile(cfgPath, []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		names, err := GetSyncTargetProfileNames("default", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(names) != 0 {
+			t.Errorf("got %v", names)
+		}
+	})
+
+	t.Run("invalid mode", func(t *testing.T) {
+		_, err := GetSyncTargetProfileNames("invalid", "")
+		if err == nil {
+			t.Error("expected error for invalid mode")
+		}
+	})
+}
+
+func TestGetReviewDays(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	path := filepath.Join(dir, "profiles.json")
+	content := `{"profiles":[
+		{"name":"no_review"},
+		{"name":"with_review","review_days":30},
+		{"name":"zero_review","review_days":0}
+	]}`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	days, has, err := GetReviewDays("no_review")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if has {
+		t.Error("no_review should not have review")
+	}
+
+	days, has, err = GetReviewDays("with_review")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has || days != 30 {
+		t.Errorf("with_review: has=%v days=%d", has, days)
+	}
+
+	_, has, _ = GetReviewDays("zero_review")
+	if has {
+		t.Error("zero_review should not have review")
+	}
+
+	_, has, err = GetReviewDays("nonexistent")
+	if err != nil || has {
+		t.Errorf("nonexistent: err=%v has=%v", err, has)
+	}
+}


### PR DESCRIPTION
## 概要
Issue #51（テストなさすぎ問題）に対応し、適切なユニットテストを追加しました。

## 変更内容

### internal/brewfile/parser_test.go
- ParseFile: tap / brew / cask / mas の各形式、コメント・空行、vscode スキップ、mas の id なしスキップ、混在入力
- 存在しないファイルでのエラー
- testdata/Brewfile を用いた統合テスト
- ResolveBrewfilePath: ユーザー指定パス、空時のカレント Brewfile 優先

### internal/config/config_test.go
- GetDefaultAliases、GetConfigDir、GetProvidersConfigPath、GetConfigPath
- LoadAppConfig（ファイルなし時）、SaveAppConfig / LoadAppConfig の往復

### internal/config/profiles_test.go
- ValidateProfileName、ParseProfileName、BuildProfileName、IsAutoSyncEnabled
- プロファイル CRUD、ResolveProfileWithExtends、GetSyncTargetProfi

## 確認
- make fmt && make vet && make test 済み