### PR TITLE
feat(brew): manage tap in provider, add provider prune (issue #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ Profile に `review_days` を設定すると、その profile のパッケージ
 
 ### Provider
 
-パッケージのインストール元。**brew**（Homebrew formula/cask/tap）、**mas**（Mac App Store）、**manual**（登録のみ、インストールは行わない）。`al init` で brew が追加される。mas は `al provider add mas`。デフォルト provider は `al config set --default-provider` で変更可能。
+パッケージのインストール元。**brew**（Homebrew formula/cask）、**mas**（Mac App Store）、**manual**（登録のみ、インストールは行わない）。`al init` で brew が追加される。mas は `al provider add mas`。デフォルト provider は `al config set --default-provider` で変更可能。
+
+**brew tap**: `brew tap` で追加する tap はパッケージとは別に provider brew 側で管理する（`~/.al/brew-taps.json`）。`al list` には tap は出さない。`al add homebrew/cask-fonts` のように tap を指定すると brew-taps に登録される。`al provider prune` では、packages に `owner/repo/toolname` 形式のパッケージが1つもない tap を untap し、brew-taps から削除する。
 
 ### link.d
 
@@ -180,13 +182,14 @@ al update
 | `al provider add <名前>` | 登録（brew / mas など） |
 | `al provider list` | 一覧 |
 | `al provider upgrade` | 全 provider のアップグレード |
+| `al provider prune` | brew のみ: brew-taps に登録されている tap のうち、packages に `owner/repo/toolname` 形式のパッケージが1つもない tap を untap し、brew-taps からも削除。homebrew/core と homebrew/cask は対象外。`--dry-run` で確認、`-y` で確認スキップ |
 
 ### al package
 
 | サブコマンド | 説明 |
 |--------------|------|
 | `al package add [名前]` | 追加（`--provider`, `--profile`, `--stage`, `--id` など） |
-| `al package list` | 一覧（`--profile` で絞り込み） |
+| `al package list` | 一覧（`--profile` で絞り込み）。brew tap は表示しない（provider 側で管理） |
 | `al package show <名前>` | 詳細 |
 | `al package remove <名前>` | 削除 |
 | `al package move <名前> --to <profile>` | 別 profile へ移動 |

--- a/cmd/package/add.go
+++ b/cmd/package/add.go
@@ -261,6 +261,27 @@ func runPackageAdd(packageName, providerName, profile, version, description, pac
 		return fmt.Errorf("unsupported provider: %s", providerName)
 	}
 
+	// Brew taps are managed by provider brew, not as packages (issue #50).
+	if providerName == "brew" && strings.HasPrefix(finalID, "tap:") {
+		tapName := strings.TrimPrefix(finalID, "tap:")
+		exists, err := config.HasBrewTap(tapName)
+		if err != nil {
+			return fmt.Errorf("error loading brew taps: %w", err)
+		}
+		if !exists {
+			if err := p.InstallPackage(finalID); err != nil {
+				return fmt.Errorf("error installing tap: %w", err)
+			}
+			if err := config.AddBrewTap(tapName); err != nil {
+				return fmt.Errorf("error saving brew taps: %w", err)
+			}
+			fmt.Printf("Tap '%s' has been added and is managed by provider brew.\n", tapName)
+		} else {
+			fmt.Printf("Tap '%s' is already managed by provider brew.\n", tapName)
+		}
+		return nil
+	}
+
 	// Check if package already exists in config
 	packagesConfig, err := config.LoadPackagesConfig()
 	if err != nil {

--- a/cmd/package/import.go
+++ b/cmd/package/import.go
@@ -143,8 +143,30 @@ func NewPackageImportCmd() *cobra.Command {
 			skipped := 0
 			brewImported := 0
 			masImported := 0
+			tapsImported := 0
 
 			for _, e := range result.Entries {
+				// Brew taps are managed by provider brew, not as packages (issue #50).
+				if e.Provider == "brew" && strings.HasPrefix(e.ID, "tap:") {
+					tapName := strings.TrimPrefix(e.ID, "tap:")
+					hasTap, err := config.HasBrewTap(tapName)
+					if err != nil {
+						return fmt.Errorf("load brew taps: %w", err)
+					}
+					if !hasTap {
+						if install && brewProv != nil {
+							if err := brewProv.InstallPackage(e.ID); err != nil {
+								return fmt.Errorf("install tap %s: %w", tapName, err)
+							}
+						}
+						if err := config.AddBrewTap(tapName); err != nil {
+							return fmt.Errorf("add brew tap %s: %w", tapName, err)
+						}
+						tapsImported++
+					}
+					continue
+				}
+
 				key := e.Provider + ":" + finalProfile + ":" + e.ID
 				if existing[key] && !overwrite {
 					skipped++
@@ -194,6 +216,9 @@ func NewPackageImportCmd() *cobra.Command {
 			}
 
 			fmt.Printf("Imported %d packages (brew: %d, mas: %d)", imported, brewImported, masImported)
+			if tapsImported > 0 {
+				fmt.Printf(", %d tap(s) (managed by provider brew)", tapsImported)
+			}
 			if skipped > 0 {
 				fmt.Printf(". Skipped %d (already registered)", skipped)
 			}

--- a/cmd/package/list.go
+++ b/cmd/package/list.go
@@ -159,9 +159,13 @@ func runPackageList(w io.Writer, profileFilter, providerFilter string) error {
 		return fmt.Errorf("error loading packages config: %w", err)
 	}
 
-	// Filter packages based on provided flags
+	// Filter packages based on provided flags.
+	// Exclude brew taps from list: taps are managed by provider brew, not as packages (see issue #50).
 	var filteredPackages []config.PackageConfig
 	for _, pkg := range packagesConfig.Packages {
+		if pkg.Provider == "brew" && strings.HasPrefix(pkg.ID, "tap:") {
+			continue
+		}
 		matchesProfile := profileFilter == "" || pkg.Profile == profileFilter
 		matchesProvider := providerFilter == "" || pkg.Provider == providerFilter
 

--- a/cmd/provider/prune.go
+++ b/cmd/provider/prune.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/kkato1030/al/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// Taps that should not be removed by prune (core/cask are commonly required).
+var protectedBrewTaps = map[string]bool{
+	"homebrew/core": true,
+	"homebrew/cask": true,
+}
+
+// NewProviderPruneCmd creates the provider prune command.
+// For brew: removes taps that are registered in al but have no package in packages.json
+// that references them (no formula/cask with owner/repo/toolname form). Issue #50.
+func NewProviderPruneCmd() *cobra.Command {
+	var providerName string
+	var dryRun bool
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Prune provider resources (e.g. remove unused brew taps)",
+		Long:  "For brew: remove taps that are in brew-taps.json but no package in packages has the form owner/repo/toolname (tap is unused). Protected taps (homebrew/core, homebrew/cask) are never removed. Use --dry-run to list what would be removed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if providerName == "" {
+				providerName = "brew"
+			}
+			if providerName != "brew" {
+				return fmt.Errorf("prune is only supported for provider 'brew' (got %q)", providerName)
+			}
+			return runProviderPruneBrew(dryRun, yes)
+		},
+	}
+
+	cmd.Flags().StringVar(&providerName, "provider", "brew", "Provider to prune (only brew is supported)")
+	cmd.Flags().StringVar(&providerName, "prv", "", "Short form of --provider")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "List taps that would be removed without removing them")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Do not ask for confirmation before removing taps")
+
+	return cmd
+}
+
+// tapFromPackageID extracts tap name "owner/repo" from brew package ID if the name part is owner/repo/toolname.
+func tapFromPackageID(id string) string {
+	// ID is "formula:owner/repo/toolname" or "cask:owner/repo/toolname"
+	idx := strings.Index(id, ":")
+	if idx < 0 {
+		return ""
+	}
+	name := id[idx+1:]
+	// name "owner/repo/toolname" → tap "owner/repo"
+	parts := strings.SplitN(name, "/", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "/" + parts[1]
+	}
+	return ""
+}
+
+func runProviderPruneBrew(dryRun, yes bool) error {
+	managed, err := config.LoadBrewTapsConfig()
+	if err != nil {
+		return fmt.Errorf("load brew taps config: %w", err)
+	}
+
+	// Build set of taps that are used by any brew package (packages have owner/repo/toolname form).
+	packagesConfig, err := config.LoadPackagesConfig()
+	if err != nil {
+		return fmt.Errorf("load packages config: %w", err)
+	}
+	usedTaps := make(map[string]bool)
+	for _, pkg := range packagesConfig.Packages {
+		if pkg.Provider != "brew" {
+			continue
+		}
+		if tap := tapFromPackageID(pkg.ID); tap != "" {
+			usedTaps[tap] = true
+		}
+	}
+
+	// Taps to remove: in managed list, not protected, not used by any package.
+	var toRemove []string
+	for _, t := range managed.Taps {
+		if protectedBrewTaps[t] {
+			continue
+		}
+		if usedTaps[t] {
+			continue
+		}
+		toRemove = append(toRemove, t)
+	}
+
+	if len(toRemove) == 0 {
+		fmt.Println("No unused brew taps to remove.")
+		return nil
+	}
+
+	if dryRun {
+		fmt.Println("Taps that would be removed (use 'al provider prune' without --dry-run to remove):")
+		for _, t := range toRemove {
+			fmt.Printf("  %s\n", t)
+		}
+		return nil
+	}
+
+	if !yes {
+		fmt.Printf("The following %d tap(s) will be removed (untap):\n", len(toRemove))
+		for _, t := range toRemove {
+			fmt.Printf("  %s\n", t)
+		}
+		fmt.Print("Continue? [y/N]: ")
+		var answer string
+		if _, err := fmt.Scanln(&answer); err != nil || (answer != "y" && answer != "Y") {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	for _, t := range toRemove {
+		untap := exec.Command("brew", "untap", t)
+		untap.Stdin = os.Stdin
+		untap.Stdout = os.Stdout
+		untap.Stderr = os.Stderr
+		if err := untap.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to untap %s: %v\n", t, err)
+		} else {
+			fmt.Printf("Untapped %s\n", t)
+		}
+		// Remove from al's brew-taps.json so we no longer manage this tap
+		if err := config.RemoveBrewTap(t); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s from brew-taps config: %v\n", t, err)
+		}
+	}
+	return nil
+}

--- a/cmd/provider/root.go
+++ b/cmd/provider/root.go
@@ -15,6 +15,7 @@ func NewProviderCmd() *cobra.Command {
 	providerCmd.AddCommand(NewProviderAddCmd())
 	providerCmd.AddCommand(NewProviderListCmd())
 	providerCmd.AddCommand(NewProviderUpgradeCmd())
+	providerCmd.AddCommand(NewProviderPruneCmd())
 
 	return providerCmd
 }

--- a/internal/config/brew_taps.go
+++ b/internal/config/brew_taps.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BrewTapsConfig holds the list of brew taps managed by al (provider brew).
+// Taps are separate from packages; see https://github.com/kkato1030/al/issues/50
+type BrewTapsConfig struct {
+	Taps []string `json:"taps"`
+}
+
+// GetBrewTapsConfigPath returns the path to brew-taps.json under the config dir.
+func GetBrewTapsConfigPath() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "brew-taps.json"), nil
+}
+
+// LoadBrewTapsConfig loads brew taps from ~/.al/brew-taps.json.
+func LoadBrewTapsConfig() (*BrewTapsConfig, error) {
+	configPath, err := GetBrewTapsConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return &BrewTapsConfig{Taps: []string{}}, nil
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	var cfg BrewTapsConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	if cfg.Taps == nil {
+		cfg.Taps = []string{}
+	}
+	return &cfg, nil
+}
+
+// SaveBrewTapsConfig writes brew taps to ~/.al/brew-taps.json.
+func SaveBrewTapsConfig(cfg *BrewTapsConfig) error {
+	if err := EnsureConfigDir(); err != nil {
+		return err
+	}
+	configPath, err := GetBrewTapsConfigPath()
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, data, 0644)
+}
+
+// AddBrewTap adds a tap name to the config if not already present.
+func AddBrewTap(tapName string) error {
+	tapName = strings.TrimSpace(tapName)
+	if tapName == "" {
+		return nil
+	}
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		return err
+	}
+	for _, t := range cfg.Taps {
+		if t == tapName {
+			return nil
+		}
+	}
+	cfg.Taps = append(cfg.Taps, tapName)
+	return SaveBrewTapsConfig(cfg)
+}
+
+// RemoveBrewTap removes a tap name from the config.
+func RemoveBrewTap(tapName string) error {
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		return err
+	}
+	for i, t := range cfg.Taps {
+		if t == tapName {
+			cfg.Taps = append(cfg.Taps[:i], cfg.Taps[i+1:]...)
+			return SaveBrewTapsConfig(cfg)
+		}
+	}
+	return nil
+}
+
+// HasBrewTap returns true if the tap is in the config.
+func HasBrewTap(tapName string) (bool, error) {
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		return false, err
+	}
+	for _, t := range cfg.Taps {
+		if t == tapName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/config/brew_taps_test.go
+++ b/internal/config/brew_taps_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadBrewTapsConfig_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg == nil || len(cfg.Taps) != 0 {
+		t.Errorf("LoadBrewTapsConfig() = %v, want empty taps", cfg)
+	}
+}
+
+func TestAddBrewTap_Save_Load(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddBrewTap("homebrew/cask-fonts"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddBrewTap("homebrew/cask"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Taps) != 2 {
+		t.Errorf("LoadBrewTapsConfig() has %d taps, want 2", len(cfg.Taps))
+	}
+
+	has, err := HasBrewTap("homebrew/cask-fonts")
+	if err != nil || !has {
+		t.Errorf("HasBrewTap(homebrew/cask-fonts) = %v, %v; want true, nil", has, err)
+	}
+}
+
+func TestAddBrewTap_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddBrewTap("user/repo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddBrewTap("user/repo"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Taps) != 1 || cfg.Taps[0] != "user/repo" {
+		t.Errorf("LoadBrewTapsConfig() = %v, want [user/repo]", cfg.Taps)
+	}
+}
+
+func TestRemoveBrewTap(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := EnsureConfigDir(); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := GetBrewTapsConfigPath()
+	if err := os.WriteFile(path, []byte(`{"taps":["a/b","c/d"]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveBrewTap("a/b"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadBrewTapsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Taps) != 1 || cfg.Taps[0] != "c/d" {
+		t.Errorf("after RemoveBrewTap(a/b), LoadBrewTapsConfig() = %v", cfg.Taps)
+	}
+
+	has, err := HasBrewTap("a/b")
+	if err != nil || has {
+		t.Errorf("HasBrewTap(a/b) = %v, %v; want false, nil", has, err)
+	}
+}
+
+func TestGetBrewTapsConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	path, err := GetBrewTapsConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "brew-taps.json")
+	if path != want {
+		t.Errorf("GetBrewTapsConfigPath() = %q, want %q", path, want)
+	}
+}

--- a/internal/provider/brew.go
+++ b/internal/provider/brew.go
@@ -144,19 +144,21 @@ func (p *BrewProvider) detectPackageType(packageName string) (string, error) {
 		return "formula", nil
 	}
 
-	// Try tap (format: tap_name/package_name or just tap_name)
+	// Try tap: "user/repo" is a tap name (installed or not)
 	if strings.Contains(packageName, "/") {
 		parts := strings.SplitN(packageName, "/", 2)
 		if len(parts) == 2 {
-			// Check if tap exists
-			cmd = exec.Command("brew", "tap-info", parts[0])
+			// Check if tap is already installed (full name: user/repo)
+			cmd = exec.Command("brew", "tap-info", packageName)
 			err = cmd.Run()
 			if err == nil {
 				return "tap", nil
 			}
+			// Not installed yet: treat "user/repo" as tap so "brew tap user/repo" runs
+			return "tap", nil
 		}
 	} else {
-		// Check if it's a tap name itself
+		// Single word: check if it's an installed tap name
 		cmd = exec.Command("brew", "tap-info", packageName)
 		err = cmd.Run()
 		if err == nil {


### PR DESCRIPTION
## Summary
Implements [issue #50](https://github.com/kkato1030/al/issues/50): tap を package と分離し、provider brew 側で管理する。

## Changes
- **Tap の管理**: tap は `~/.al/brew-taps.json` で管理。`al list` には tap を表示しない。
- **al add / import**: tap と判定されたものは packages ではなく brew-taps に登録。tap 経由の formula/cask は従来どおり packages で管理。
- **detectPackageType**: `user/repo` 形式で cask/formula でなければ tap とみなす（未インストールの tap も `al add owner/repo` で追加可能に）。
- **al provider prune**: brew-taps に登録されている tap のうち、packages に `owner/repo/toolname` 形式のパッケージが1つもない tap を untap し、brew-taps からも削除。`homebrew/core` と `homebrew/cask` は対象外。`--dry-run` / `-y` 対応。
- README の概念・コマンドリファレンスを更新。

## Checklist
- [x] `cmd/` の実装を変更した
- [x] README.md を更新した
- [x] internal/config に brew_taps のユニットテストを追加

Made with [Cursor](https://cursor.com)