### PR TITLE
Custom headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Profile に `review_days` を設定すると、その profile のパッケージ
 
 パッケージのインストール元。**brew**（Homebrew formula/cask）、**mas**（Mac App Store）、**manual**（登録のみ、インストールは行わない）。`al init` で brew が追加される。mas は `al provider add mas`。デフォルト provider は `al config set --default-provider` で変更可能。
 
+provider 間の依存関係は `providers.json` の `depends_on` で管理される。デフォルトでは **mas は brew に依存**（`depends_on: ["brew"]`）し、`al provider add mas` や `al sync` では依存順（brew → mas）で処理される。
+
 **brew tap**: `brew tap` で追加する tap はパッケージとは別に provider brew 側で管理する（`~/.al/brew-taps.json`）。`al list` には tap は出さない。`al add homebrew/cask-fonts` のように tap を指定すると brew-taps に登録される。tap の更新（Homebrew と全 tap の最新化）は `al provider upgrade` または `al upgrade` で行う（brew の場合は内部で `brew update` が実行される）。`al provider prune` では、packages に `owner/repo/toolname` 形式のパッケージが1つもない tap を untap し、brew-taps から削除する。
 
 ### link.d
@@ -179,7 +181,7 @@ al update
 
 | サブコマンド | 説明 |
 |--------------|------|
-| `al provider add <名前>` | 登録（brew / mas など） |
+| `al provider add <名前>` | 登録（brew / mas など）。依存関係（例: mas → brew）も自動で解決して先に処理 |
 | `al provider list` | 一覧 |
 | `al provider upgrade [provider-name]` | provider のアップグレード（未指定時は全 provider）。brew の場合は `brew update` により Homebrew と全 tap が更新される |
 | `al provider prune` | brew のみ: brew-taps に登録されている tap のうち、packages に `owner/repo/toolname` 形式のパッケージが1つもない tap を untap し、brew-taps からも削除。homebrew/core と homebrew/cask は対象外。`--dry-run` で確認、`-y` で確認スキップ |

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/kkato1030/al/internal/config"
 	"github.com/kkato1030/al/internal/provider"
 	"github.com/spf13/cobra"
 )
@@ -20,46 +22,67 @@ func NewProviderAddCmd() *cobra.Command {
 
 func runProviderAdd(cmd *cobra.Command, args []string) error {
 	providerName := args[0]
-	var p provider.Provider
 
-	switch providerName {
-	case "brew":
-		p = provider.NewBrewProvider()
-	case "mas":
-		p = provider.NewMasProvider()
-	case "manual":
-		p = provider.NewManualProvider()
-	default:
-		return fmt.Errorf("unknown provider: %s\nAvailable providers: brew, mas, manual", providerName)
+	orderedProviders, err := config.ResolveProvidersWithDependencies([]string{providerName})
+	if err != nil {
+		return fmt.Errorf("error resolving provider dependencies: %w", err)
 	}
 
-	// Check if already installed
+	if len(orderedProviders) > 1 {
+		fmt.Printf("Resolved provider dependencies: %s\n", strings.Join(orderedProviders, " -> "))
+	}
+
+	for _, name := range orderedProviders {
+		if err := addProvider(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addProvider(providerName string) error {
+	p, err := providerFromName(providerName)
+	if err != nil {
+		return err
+	}
+
 	installed, err := p.CheckInstalled()
 	if err != nil {
-		return fmt.Errorf("error checking installation: %w", err)
+		return fmt.Errorf("error checking installation for %s: %w", providerName, err)
 	}
 
 	if installed {
 		fmt.Printf("%s is already installed\n", providerName)
-		// Still set up config in case it's not configured
 		if err := p.SetupConfig(); err != nil {
-			fmt.Printf("Warning: failed to set up config: %v\n", err)
+			fmt.Printf("Warning: failed to set up config for %s: %v\n", providerName, err)
 		}
 		return nil
 	}
 
-	// Install the provider
 	fmt.Printf("Installing %s...\n", providerName)
 	if err := p.Install(); err != nil {
 		return fmt.Errorf("error installing %s: %w", providerName, err)
 	}
 
-	// Set up config
 	fmt.Printf("Setting up configuration for %s...\n", providerName)
 	if err := p.SetupConfig(); err != nil {
-		return fmt.Errorf("error setting up config: %w", err)
+		return fmt.Errorf("error setting up config for %s: %w", providerName, err)
 	}
 
 	fmt.Printf("%s has been successfully installed and configured\n", providerName)
 	return nil
+}
+
+func providerFromName(providerName string) (provider.Provider, error) {
+	switch providerName {
+	case "brew":
+		return provider.NewBrewProvider(), nil
+	case "mas":
+		return provider.NewMasProvider(), nil
+	case "manual":
+		return provider.NewManualProvider(), nil
+	default:
+		return nil, fmt.Errorf("unknown provider: %s\nAvailable providers: brew, mas, manual", providerName)
+	}
 }

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kkato1030/al/internal/config"
 	"github.com/spf13/cobra"
@@ -18,24 +19,31 @@ func NewProviderListCmd() *cobra.Command {
 }
 
 func runProviderList(cmd *cobra.Command, args []string) error {
-	config, err := config.LoadProvidersConfig()
+	providersCfg, err := config.LoadProvidersConfig()
 	if err != nil {
 		return fmt.Errorf("error loading providers config: %w", err)
 	}
 
-	if len(config.Providers) == 0 {
+	if len(providersCfg.Providers) == 0 {
 		fmt.Println("No providers installed")
 		return nil
 	}
 
 	fmt.Println("Installed providers:")
-	for _, p := range config.Providers {
+	for _, p := range providersCfg.Providers {
 		fmt.Printf("  - %s", p.Name)
 		if p.Version != "" {
 			fmt.Printf(" (version: %s)", p.Version)
 		}
 		if !p.InstalledAt.IsZero() {
 			fmt.Printf(" (installed at: %s)", p.InstalledAt.Format("2006-01-02 15:04:05"))
+		}
+		deps := p.DependsOn
+		if deps == nil {
+			deps = config.GetDefaultProviderDependencies(p.Name)
+		}
+		if len(deps) > 0 {
+			fmt.Printf(" (depends_on: %s)", strings.Join(deps, ", "))
 		}
 		fmt.Println()
 	}

--- a/cmd/provider/upgrade.go
+++ b/cmd/provider/upgrade.go
@@ -48,13 +48,25 @@ func runProviderUpgradeAll(yes bool) error {
 		return nil
 	}
 
+	providerVersions := make(map[string]string, len(providersConfig.Providers))
+	var providerNames []string
+	for _, p := range providersConfig.Providers {
+		providerVersions[p.Name] = p.Version
+		providerNames = append(providerNames, p.Name)
+	}
+
+	orderedProviders, err := config.OrderProvidersByDependency(providerNames)
+	if err != nil {
+		return fmt.Errorf("error resolving provider upgrade order: %w", err)
+	}
+
 	// Ask for confirmation
 	if !yes {
-		fmt.Printf("This will upgrade all %d provider(s):\n", len(providersConfig.Providers))
-		for _, p := range providersConfig.Providers {
-			fmt.Printf("  - %s", p.Name)
-			if p.Version != "" {
-				fmt.Printf(" (current version: %s)", p.Version)
+		fmt.Printf("This will upgrade all %d provider(s):\n", len(orderedProviders))
+		for _, name := range orderedProviders {
+			fmt.Printf("  - %s", name)
+			if providerVersions[name] != "" {
+				fmt.Printf(" (current version: %s)", providerVersions[name])
 			}
 			fmt.Println()
 		}
@@ -68,10 +80,10 @@ func runProviderUpgradeAll(yes bool) error {
 	}
 
 	// Upgrade each provider
-	for _, providerConfig := range providersConfig.Providers {
-		fmt.Printf("\nUpgrading provider: %s\n", providerConfig.Name)
-		if err := runProviderUpgrade(providerConfig.Name); err != nil {
-			fmt.Printf("Error upgrading %s: %v\n", providerConfig.Name, err)
+	for _, providerName := range orderedProviders {
+		fmt.Printf("\nUpgrading provider: %s\n", providerName)
+		if err := runProviderUpgrade(providerName); err != nil {
+			fmt.Printf("Error upgrading %s: %v\n", providerName, err)
 			continue
 		}
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -156,13 +156,17 @@ func runSync(dryRun, all bool, profileName string, usePrivate bool, pkgOnly bool
 		if err != nil {
 			return fmt.Errorf("load packages: %w", err)
 		}
-		providersNeeded := make(map[string]bool)
+		var providersNeeded []string
 		for _, pkg := range packagesCfg.Packages {
 			if syncTargetSet[pkg.Profile] && pkg.Provider != "manual" {
-				providersNeeded[pkg.Provider] = true
+				providersNeeded = append(providersNeeded, pkg.Provider)
 			}
 		}
-		for name := range providersNeeded {
+		orderedProviders, err := config.ResolveProvidersWithDependencies(providersNeeded)
+		if err != nil {
+			return fmt.Errorf("resolve provider dependencies: %w", err)
+		}
+		for _, name := range orderedProviders {
 			p := getProvider(name)
 			if p == nil {
 				continue

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -11,11 +14,26 @@ type ProviderConfig struct {
 	Name        string    `json:"name"`
 	InstalledAt time.Time `json:"installed_at"`
 	Version     string    `json:"version,omitempty"`
+	DependsOn   []string  `json:"depends_on,omitempty"`
 }
 
 // ProvidersConfig represents the collection of provider configurations
 type ProvidersConfig struct {
 	Providers []ProviderConfig `json:"providers"`
+}
+
+// defaultProviderDependencies defines default dependencies between providers.
+var defaultProviderDependencies = map[string][]string{
+	"mas": {"brew"},
+}
+
+// GetDefaultProviderDependencies returns default dependencies for a provider.
+func GetDefaultProviderDependencies(providerName string) []string {
+	deps, ok := defaultProviderDependencies[providerName]
+	if !ok {
+		return nil
+	}
+	return copyStringSlice(deps)
 }
 
 // LoadProvidersConfig loads the providers configuration from JSON file
@@ -70,10 +88,17 @@ func AddOrUpdateProvider(provider ProviderConfig) error {
 		return err
 	}
 
+	provider.Name = strings.TrimSpace(provider.Name)
+	provider.DependsOn = normalizeProviderDependencies(provider.Name, provider.DependsOn)
+
 	// Check if provider already exists
 	found := false
 	for i, p := range config.Providers {
 		if p.Name == provider.Name {
+			if provider.DependsOn == nil {
+				// Keep existing dependency settings when callers only update version/timestamps.
+				provider.DependsOn = resolveConfiguredProviderDependencies(provider.Name, p.DependsOn)
+			}
 			config.Providers[i] = provider
 			found = true
 			break
@@ -82,6 +107,9 @@ func AddOrUpdateProvider(provider ProviderConfig) error {
 
 	// If not found, add it
 	if !found {
+		if provider.DependsOn == nil {
+			provider.DependsOn = GetDefaultProviderDependencies(provider.Name)
+		}
 		config.Providers = append(config.Providers, provider)
 	}
 
@@ -102,4 +130,186 @@ func GetProvider(name string) (*ProviderConfig, error) {
 	}
 
 	return nil, nil // Provider not found
+}
+
+// OrderProvidersByDependency sorts providers so dependencies come first.
+// Dependencies outside of providerNames are ignored.
+func OrderProvidersByDependency(providerNames []string) ([]string, error) {
+	uniqueNames := uniqueProviderNames(providerNames)
+	if len(uniqueNames) == 0 {
+		return []string{}, nil
+	}
+
+	providerDeps, err := loadProviderDependencyMap()
+	if err != nil {
+		return nil, err
+	}
+
+	return topologicalSortProviders(uniqueNames, providerDeps)
+}
+
+// ResolveProvidersWithDependencies expands providerNames with dependencies and sorts them.
+func ResolveProvidersWithDependencies(providerNames []string) ([]string, error) {
+	uniqueNames := uniqueProviderNames(providerNames)
+	if len(uniqueNames) == 0 {
+		return []string{}, nil
+	}
+
+	providerDeps, err := loadProviderDependencyMap()
+	if err != nil {
+		return nil, err
+	}
+
+	expandedSet := make(map[string]bool)
+	queue := make([]string, 0, len(uniqueNames))
+	for _, name := range uniqueNames {
+		if !expandedSet[name] {
+			expandedSet[name] = true
+			queue = append(queue, name)
+		}
+	}
+
+	for i := 0; i < len(queue); i++ {
+		name := queue[i]
+		for _, dep := range resolveConfiguredProviderDependencies(name, providerDeps[name]) {
+			if dep == "" || dep == name {
+				continue
+			}
+			if !expandedSet[dep] {
+				expandedSet[dep] = true
+				queue = append(queue, dep)
+			}
+		}
+	}
+
+	expandedNames := make([]string, 0, len(expandedSet))
+	for name := range expandedSet {
+		expandedNames = append(expandedNames, name)
+	}
+
+	return topologicalSortProviders(expandedNames, providerDeps)
+}
+
+func loadProviderDependencyMap() (map[string][]string, error) {
+	cfg, err := LoadProvidersConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	depsByProvider := make(map[string][]string, len(cfg.Providers))
+	for _, p := range cfg.Providers {
+		depsByProvider[p.Name] = normalizeProviderDependencies(p.Name, p.DependsOn)
+	}
+	return depsByProvider, nil
+}
+
+func topologicalSortProviders(providerNames []string, depsByProvider map[string][]string) ([]string, error) {
+	set := make(map[string]bool, len(providerNames))
+	for _, name := range providerNames {
+		set[name] = true
+	}
+
+	inDegree := make(map[string]int, len(providerNames))
+	dependents := make(map[string][]string, len(providerNames))
+	for _, name := range providerNames {
+		inDegree[name] = 0
+	}
+
+	for _, name := range providerNames {
+		depSeen := make(map[string]bool)
+		for _, dep := range resolveConfiguredProviderDependencies(name, depsByProvider[name]) {
+			if dep == "" || dep == name || !set[dep] || depSeen[dep] {
+				continue
+			}
+			depSeen[dep] = true
+			inDegree[name]++
+			dependents[dep] = append(dependents[dep], name)
+		}
+	}
+
+	var queue []string
+	for _, name := range providerNames {
+		if inDegree[name] == 0 {
+			queue = append(queue, name)
+		}
+	}
+	sort.Strings(queue)
+
+	var order []string
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		order = append(order, current)
+
+		next := append([]string(nil), dependents[current]...)
+		sort.Strings(next)
+		for _, name := range next {
+			inDegree[name]--
+			if inDegree[name] == 0 {
+				queue = append(queue, name)
+			}
+		}
+		sort.Strings(queue)
+	}
+
+	if len(order) != len(providerNames) {
+		cycleNames := append([]string(nil), providerNames...)
+		sort.Strings(cycleNames)
+		return nil, fmt.Errorf("provider: cycle in depends_on dependency (%s)", strings.Join(cycleNames, ", "))
+	}
+
+	return order, nil
+}
+
+func uniqueProviderNames(providerNames []string) []string {
+	seen := make(map[string]bool, len(providerNames))
+	var unique []string
+	for _, name := range providerNames {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		unique = append(unique, trimmed)
+	}
+	return unique
+}
+
+func normalizeProviderDependencies(providerName string, dependsOn []string) []string {
+	if dependsOn == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(dependsOn))
+	var normalized []string
+	for _, dep := range dependsOn {
+		trimmed := strings.TrimSpace(dep)
+		if trimmed == "" || trimmed == providerName || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		normalized = append(normalized, trimmed)
+	}
+
+	if len(normalized) == 0 {
+		return []string{}
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func resolveConfiguredProviderDependencies(providerName string, configured []string) []string {
+	if configured != nil {
+		return copyStringSlice(configured)
+	}
+	return GetDefaultProviderDependencies(providerName)
+}
+
+func copyStringSlice(src []string) []string {
+	if src == nil {
+		return nil
+	}
+	dst := make([]string, len(src))
+	copy(dst, src)
+	return dst
 }

--- a/internal/config/providers_test.go
+++ b/internal/config/providers_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestAddOrUpdateProvider_SetsDefaultDependencies(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	providerCfg := ProviderConfig{
+		Name:        "mas",
+		InstalledAt: time.Now(),
+		Version:     "1.0.0",
+	}
+	if err := AddOrUpdateProvider(providerCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetProvider("mas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("GetProvider(mas) returned nil")
+	}
+
+	wantDeps := []string{"brew"}
+	if !reflect.DeepEqual(got.DependsOn, wantDeps) {
+		t.Errorf("mas depends_on = %v, want %v", got.DependsOn, wantDeps)
+	}
+}
+
+func TestAddOrUpdateProvider_PreservesExistingDependenciesWhenOmitted(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := AddOrUpdateProvider(ProviderConfig{
+		Name:        "mas",
+		InstalledAt: time.Now(),
+		Version:     "1.0.0",
+		DependsOn:   []string{"brew", "manual"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate version refresh where caller doesn't send depends_on.
+	if err := AddOrUpdateProvider(ProviderConfig{
+		Name:        "mas",
+		InstalledAt: time.Now(),
+		Version:     "2.0.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetProvider("mas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("GetProvider(mas) returned nil")
+	}
+
+	wantDeps := []string{"brew", "manual"}
+	if !reflect.DeepEqual(got.DependsOn, wantDeps) {
+		t.Errorf("mas depends_on after update = %v, want %v", got.DependsOn, wantDeps)
+	}
+}
+
+func TestOrderProvidersByDependency_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	got, err := OrderProvidersByDependency([]string{"mas", "brew"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"brew", "mas"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("OrderProvidersByDependency() = %v, want %v", got, want)
+	}
+}
+
+func TestResolveProvidersWithDependencies_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	got, err := ResolveProvidersWithDependencies([]string{"mas"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"brew", "mas"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ResolveProvidersWithDependencies() = %v, want %v", got, want)
+	}
+}
+
+func TestOrderProvidersByDependency_Cycle(t *testing.T) {
+	dir := t.TempDir()
+	restore := setEnv("AL_HOME", dir)
+	defer restore()
+
+	if err := SaveProvidersConfig(&ProvidersConfig{
+		Providers: []ProviderConfig{
+			{Name: "a", DependsOn: []string{"b"}},
+			{Name: "b", DependsOn: []string{"a"}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := OrderProvidersByDependency([]string{"a", "b"}); err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+}


### PR DESCRIPTION
Adds provider dependency management to resolve and process providers in the correct order, addressing issue #21.

This change introduces a robust dependency resolution mechanism to ensure a logical and correct operational flow for `add`, `sync`, and `upgrade` commands, particularly for providers like `mas` that may rely on `brew` being present or configured first.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-45340c5d-1cc4-4e25-9247-e377468b5591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45340c5d-1cc4-4e25-9247-e377468b5591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution order for provider install/upgrade and sync setup via new dependency resolution logic; mistakes could cause providers to run in the wrong order or fail due to misconfigured cycles/defaults.
> 
> **Overview**
> Introduces provider dependency management via a new `depends_on` field in `providers.json`, with defaults (notably `mas` → `brew`) and cycle-detecting topological ordering utilities.
> 
> Updates `al provider add`, `al sync`, and `al provider upgrade` to expand/sort providers by dependencies before installing/configuring/upgrading, and enhances `al provider list` plus README docs to surface these dependencies. Adds unit tests covering default dependency assignment, preservation on update, ordering, dependency expansion, and cycle errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b350c506d68504f7f3d64430667f35d87e784a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->