### PR TITLE
chore: README の QuickStart で import を推し、brew/mas ユーザーの移行を促す

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,26 +8,43 @@
 
 ## Quick Start
 
-**インストール**
+**インストール**（どちらのパスも共通）
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kkato1030/al/main/install.sh | bash
 al version
 ```
 
-**初期化**（対話式は `al init --guided`）
+自分に合ったパスを選んでください。
+
+### すでに Homebrew / mas を使っている人 — import で一発移行
+
+すでに `brew`（や `mas`）でパッケージを管理しているなら、ゼロからやり直す必要はありません。`al import` で **今の環境**をそのまま al の管理下に取り込めます。これが最短の移行方法です。
 
 ```bash
-al init
+al init                        # ~/.al をセットアップ
+al profile add core            # 取り込み先の profile を作成
+al import --prf core --dry-run # 登録される内容をプレビュー
+al import --prf core           # 現在インストール済みのパッケージを登録
 ```
 
-**パッケージの追加**
+すでに `Brewfile` がある場合は、それを直接取り込めます:
 
 ```bash
-al add jq
+al import Brewfile --prf core             # 登録のみ
+al import Brewfile --prf core --install   # 未インストール分もインストール
 ```
 
-**シェルの有効化** — `.zshrc` または `.bashrc` に追加:
+`al import`（自動検出）は明示的にインストールしたパッケージ（`brew leaves`）と cask・mas アプリのみを対象にします。詳細は **[Brewfile からの移行](docs/ja/brewfile-migration.md)** を参照。
+
+### ゼロから使い始める人
+
+```bash
+al init            # 対話式は: al init --guided
+al add jq          # パッケージの追加
+```
+
+**シェルの有効化**（どちらも共通） — `.zshrc` または `.bashrc` に追加:
 
 ```bash
 eval "$(al activate zsh)"   # または bash

--- a/README.md
+++ b/README.md
@@ -8,26 +8,43 @@
 
 ## Quick Start
 
-**Install**
+**Install** (both paths start here)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kkato1030/al/main/install.sh | bash
 al version
 ```
 
-**Initialize** (use `al init --guided` for interactive setup)
+Pick the path that matches you.
+
+### Already using Homebrew / mas? Import in one step
+
+If you already manage packages with `brew` (and maybe `mas`), you don't have to start over — bring your **current environment** under al with `al import`. This is the fastest way to migrate.
 
 ```bash
-al init
+al init                        # set up ~/.al
+al profile add core            # create a profile to import into
+al import --prf core --dry-run # preview what would be registered
+al import --prf core           # register your currently installed packages
 ```
 
-**Add a package**
+Already have a `Brewfile`? Import it directly:
 
 ```bash
-al add jq
+al import Brewfile --prf core             # register only
+al import Brewfile --prf core --install   # also install missing packages
 ```
 
-**Enable shell** — add to `.zshrc` or `.bashrc`:
+`al import` (auto-detect) only picks up explicitly installed packages (`brew leaves`), plus casks and mas apps. See **[Brewfile migration](docs/en/brewfile-migration.md)** for details.
+
+### Starting from scratch
+
+```bash
+al init            # or: al init --guided  for interactive setup
+al add jq          # add a package
+```
+
+**Enable shell** (both paths) — add to `.zshrc` or `.bashrc`:
 
 ```bash
 eval "$(al activate zsh)"   # or bash


### PR DESCRIPTION
## 概要

Issue #113 の対応。README の QuickStart を **2つのパス**に分離し、既存の brew/mas ユーザーの移行を後押しする。

## 変更内容

`README.md` / `README.ja.md` の QuickStart を以下の2セクションに再構成:

- **すでに Homebrew / mas を使っている人** — `al import` を最短の移行手段として先頭に配置。自動検出（`al import --prf core`）と `Brewfile` からの取り込みの両方を掲載し、Brewfile migration ドキュメントへ誘導。
- **ゼロから使い始める人** — 従来の `al init` → `al add` の流れ。

共通のインストール手順・シェル有効化・GitHub 同期/バックアップはそのまま維持。

## 背景

ほとんどのユーザーはすでに brew を使っているため、「やり直し不要でそのまま取り込める」ことを最初に見せてユーザー移行を狙う。

Closes #113

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>